### PR TITLE
fix fcnt

### DIFF
--- a/src/lorawan_mac.erl
+++ b/src/lorawan_mac.erl
@@ -134,10 +134,10 @@ check_link(DevAddr, FCnt) ->
     end.
 
 fcnt_gap(A, B) ->
-    C = A band 16#FFFF,
+    A16 = A band 16#FFFF,
     if
-        C > B -> 16#FFFF - C + B;
-        true  -> B - C
+        A16 > B -> 16#FFFF - A16 + B;
+        true  -> B - A16
     end.
 
 store_rxpk(MAC, RxQ, RF, DevAddr, FCnt, Data) ->

--- a/src/lorawan_mac.erl
+++ b/src/lorawan_mac.erl
@@ -163,10 +163,7 @@ handle_rxpk(RxQ, 2, DevAddr, App, AppID, Port, Data) ->
 txpk(Time, RF, DevAddr, FPort, Data) ->
     {atomic, L} = mnesia:transaction(fun() ->
         [D] = mnesia:read(links, DevAddr, write),
-        FCnt =  case D#link.fcntdown of
-                    N when N < 16#FFFF -> N+1;
-                    _Else -> 0
-                end,
+        FCnt =  (D#link.fcntdown + 1) band 16#FFFFFFFF,
         NewD = D#link{fcntdown=FCnt},
         mnesia:write(links, NewD, write),
         NewD


### PR DESCRIPTION
LoRaWAN says:
> The  LoRaWAN  allows the use of either 16-bits or  32-bits frame counters. 

But the codes in [LoRaMac-node][1] :
```C
/*!
 * LoRaMAC frame counter. Each time a packet is sent the counter is incremented.
 * Only the 16 LSB bits are sent
 */
static uint32_t UpLinkCounter = 1;

/*!
 * LoRaMAC frame counter. Each time a packet is received the counter is incremented.
 * Only the 16 LSB bits are received
 */
static uint32_t DownLinkCounter = 0;
```

And, it is better use **32bits** instead of **16bits** in  [lorawan-server][2]

[1]: https://github.com/Lora-net/LoRaMac-node/blob/master/src/mac/LoRaMac.c
[2]: https://github.com/gotthardp/lorawan-server