### PR TITLE
fix fcnt when fcnt > 16#FFFF

### DIFF
--- a/src/lorawan_mac.erl
+++ b/src/lorawan_mac.erl
@@ -144,7 +144,7 @@ check_link(DevAddr, FCnt) ->
 fcnt_gap(A, B) ->
     A16 = A band 16#FFFF,
     if
-        A16 > B -> 16#FFFF - A16 + B;
+        A16 > B -> 16#10000 - A16 + B;
         true  -> B - A16
     end.
 


### PR DESCRIPTION
Hi,
There is a bug in my commit `f1b5bc1523e53a4e58e26d906bee0a68b9615225`.
For example:
```Erlang
UpLinkCounter = 66000.
FCnt = 66000 band 16#FFFF.
LocalFCnt = 65000.
%% Bug :  999 = Gap = 16#FFFF - (LocalFCnt band 16#FFFF) + FCnt.
%% Right: 
Gap = 16#10000 - (LocalFCnt band 16#FFFF) + FCnt.
```