### PR TITLE
Temporary fix to enable Japan's channel plan.

### DIFF
--- a/priv/admin/admin.js
+++ b/priv/admin/admin.js
@@ -63,16 +63,17 @@ myApp.config(['NgAdminConfigurationProvider', function (nga) {
         { value: 'EU433', label: 'EU 433MHz' },
         { value: 'AU915-928', label: 'Australia 915-928MHz' },
         { value: 'CN470-510', label: 'China 470-510MHz' },
-        { value: 'KR920-923', label: 'South Korea 920-923MHz' }
+        { value: 'KR920-923', label: 'South Korea 920-923MHz' },
+        { value: 'AS923-JP', label: 'Japan 920.6-923.4MHz' }
     ];
 
     data_rate_choices = [
-        { value: 0, label: 'SF12 125 kHz (250 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923'] },
-        { value: 1, label: 'SF11 125 kHz (440 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923'] },
-        { value: 2, label: 'SF10 125 kHz (980 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923'] },
-        { value: 3, label: 'SF9 125 kHz (1760 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923'] },
-        { value: 4, label: 'SF8 125 kHz (3125 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923'] },
-        { value: 5, label: 'SF7 125 kHz (5470 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923'] },
+        { value: 0, label: 'SF12 125 kHz (250 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923', 'AS923-JP'] },
+        { value: 1, label: 'SF11 125 kHz (440 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923', 'AS923-JP'] },
+        { value: 2, label: 'SF10 125 kHz (980 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923', 'AS923-JP'] },
+        { value: 3, label: 'SF9 125 kHz (1760 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923', 'AS923-JP'] },
+        { value: 4, label: 'SF8 125 kHz (3125 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923', 'AS923-JP'] },
+        { value: 5, label: 'SF7 125 kHz (5470 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433', 'CN470-510', 'KR920-923', 'AS923-JP'] },
         { value: 6, label: 'SF7 250 kHz (11000 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433'] },
         { value: 7, label: '50 kbps (50000 bit/s)', regions: ['EU863-870', 'CN779-787', 'EU433'] },
 
@@ -125,7 +126,15 @@ myApp.config(['NgAdminConfigurationProvider', function (nga) {
         { value: 3, label: '8 dBm', regions: ['KR920-923'] },
         { value: 4, label: '5 dBm', regions: ['KR920-923'] },
         { value: 5, label: '2 dBm', regions: ['KR920-923'] },
-        { value: 6, label: '0 dBm', regions: ['KR920-923'] }
+        { value: 6, label: '0 dBm', regions: ['KR920-923'] },
+
+        { value: 0, label: '13 dBm', regions: ['AS923-JP'] },
+        { value: 1, label: '12 dBm', regions: ['AS923-JP'] },
+        { value: 2, label: '10 dBm', regions: ['AS923-JP'] },
+        { value: 3, label: '8 dBm', regions: ['AS923-JP'] },
+        { value: 4, label: '6 dBm', regions: ['AS923-JP'] },
+        { value: 5, label: '4 dBm', regions: ['AS923-JP'] },
+        { value: 6, label: '0 dBm', regions: ['AS923-JP'] }
     ];
 
     format_choices = [

--- a/src/lorawan_mac_commands.erl
+++ b/src/lorawan_mac_commands.erl
@@ -241,7 +241,7 @@ send_adr(Link, FOptsOut) ->
     end.
 
 set_channels(Region, {TXPower, DataRate, Chans}, FOptsOut)
-        when Region == <<"EU863-870">>; Region == <<"CN779-787">>; Region == <<"EU433">>; Region == <<"KR920-923">> ->
+        when Region == <<"EU863-870">>; Region == <<"CN779-787">>; Region == <<"EU433">>; Region == <<"KR920-923">>; Region == <<"AS923-JP">> ->
     [{link_adr_req, DataRate, TXPower, build_bin(Chans, {0, 15}), 0, 0} | FOptsOut];
 set_channels(Region, {TXPower, DataRate, Chans}, FOptsOut)
         when Region == <<"US902-928">>; Region == <<"US902-928-PR">>; Region == <<"AU915-928">> ->

--- a/src/lorawan_mac_region.erl
+++ b/src/lorawan_mac_region.erl
@@ -32,7 +32,7 @@ rx1_rf(Link, RxQ) ->
 
 % we calculate in fixed-point numbers
 rx1_rf(Region, RxQ, Offset)
-        when Region == <<"EU863-870">>; Region == <<"CN779-787">>; Region == <<"EU433">>; Region == <<"KR920-923">> ->
+        when Region == <<"EU863-870">>; Region == <<"CN779-787">>; Region == <<"EU433">>; Region == <<"KR920-923">>; Region == <<"AS923-JP">> ->
     rf_same(Region, RxQ, RxQ#rxq.freq, Offset);
 rx1_rf(<<"US902-928">> = Region, RxQ, Offset) ->
     RxCh = f2ch(RxQ#rxq.freq, {9023, 2}, {9030, 16}),
@@ -100,7 +100,7 @@ datar_to_down(Region, DataRate, Offset) ->
 
 dr_to_down(Region, DR)
         when Region == <<"EU863-870">>; Region == <<"CN779-787">>; Region == <<"EU433">>;
-             Region == <<"CN470-510">>; Region == <<"KR920-923">> ->
+             Region == <<"CN470-510">>; Region == <<"KR920-923">>; Region == <<"AS923-JP">> ->
     case DR of
         0 -> [0, 0, 0, 0, 0, 0];
         1 -> [1, 0, 0, 0, 0, 0];
@@ -125,7 +125,7 @@ dr_to_down(Region, DR)
 
 datars(Region)
         when Region == <<"EU863-870">>; Region == <<"CN779-787">>; Region == <<"EU433">>;
-             Region == <<"CN470-510">>; Region == <<"KR920-923">> -> [
+             Region == <<"CN470-510">>; Region == <<"KR920-923">>; Region == <<"AS923-JP">> -> [
     {0, {12, 125}},
     {1, {11, 125}},
     {2, {10, 125}},
@@ -226,6 +226,15 @@ powers(Region)
     {3, 8},
     {4, 5},
     {5, 2},
+    {6, 0}];
+powers(Region)
+        when Region == <<"AS923-JP">> -> [
+    {0, 13},
+    {1, 12},
+    {2, 10},
+    {3, 8},
+    {4, 6},
+    {5, 4},
     {6, 0}].
 
 powe_to_num(Region, Pow) ->
@@ -247,7 +256,8 @@ default_adr(<<"CN779-787">>) -> {1, 0, [{0,2}]};
 default_adr(<<"EU433">>) -> {0, 0, [{0,2}]};
 default_adr(<<"AU915-928">>) -> {5, 0, [{0,71}]};
 default_adr(<<"CN470-510">>) -> {2, 0, [{0, 95}]};
-default_adr(<<"KR920-923">>) -> {1, 0, [{0, 2}]}.
+default_adr(<<"KR920-923">>) -> {1, 0, [{0, 2}]};
+default_adr(<<"AS923-JP">>) -> {1, 0, [{0, 1}]}.
 
 % {RX1DROffset, RX2DataRate, Frequency}
 default_rxwin(Region) ->
@@ -262,7 +272,8 @@ max_adr(<<"CN779-787">>) -> {5, 6};
 max_adr(<<"EU433">>) -> {5, 6};
 max_adr(<<"AU915-928">>) -> {10, 4};
 max_adr(<<"CN470-510">>) -> {7, 6};
-max_adr(<<"KR920-923">>) -> {6, 5}.
+max_adr(<<"KR920-923">>) -> {6, 5};
+max_adr(<<"AS923-JP">>) -> {6, 5}.
 
 % {default, maximal} power for downlinks (dBm)
 eirp_limits(<<"EU863-870">>) -> {14, 20};
@@ -272,7 +283,8 @@ eirp_limits(<<"CN779-787">>) -> {10, 10};
 eirp_limits(<<"EU433">>) -> {10, 10};
 eirp_limits(<<"AU915-928">>) -> {20, 26};
 eirp_limits(<<"CN470-510">>) -> {14, 17};
-eirp_limits(<<"KR920-923">>) -> {14, 23}.
+eirp_limits(<<"KR920-923">>) -> {14, 23};
+eirp_limits(<<"AS923-JP">>) -> {13, 13}.
 
 % {Min, Max}
 freq_range(<<"EU863-870">>) -> {863, 870};
@@ -282,7 +294,8 @@ freq_range(<<"CN779-787">>) -> {779, 787};
 freq_range(<<"EU433">>) -> {433, 435};
 freq_range(<<"AU915-928">>) -> {915, 928};
 freq_range(<<"CN470-510">>) -> {470, 510};
-freq_range(<<"KR920-923">>) -> {920, 923}.
+freq_range(<<"KR920-923">>) -> {920, 923};
+freq_range(<<"AS923-JP">>) -> {920.6, 923.4}.
 
 tx_time(#txdata{data=Data}, TxQ) ->
     tx_time(byte_size(Data), TxQ);

--- a/src/lorawan_server.app.src
+++ b/src/lorawan_server.app.src
@@ -52,6 +52,9 @@
             ]},
             {<<"KR920-923">>, [
                 {rx2_rf, {921.9, <<"SF12BW125">>, <<"4/5">>}}
+            ]},
+            {<<"AS923-JP">>, [
+                {rx2_rf, {923.2, <<"SF10BW125">>, <<"4/5">>}}
             ]}
         ]},
         % {sec, fcnt} after which the device status should be request


### PR DESCRIPTION
This fix enables Japan's channel plan temporay.
Supposed regulation is below.
 Freq: 920.6MHz - 923.4MHz (200kWHz)
 Transmit power: <=20mW (13dBm)
 LBT: 5msec
 Duty Cycle: no limit