### PR TITLE
An example approach of extensions handling

### DIFF
--- a/lorawan_server.config
+++ b/lorawan_server.config
@@ -7,6 +7,8 @@
         {<<"microchip-mote">>, lorawan_application_microchip_mote},
         {<<"backend">>, lorawan_application_backend},
         {<<"websocket">>, lorawan_application_websocket}]},
+    {extensions, [
+        ]},
     % UDP port listening for packets from the packet_forwarder Gateway
     {packet_forwarder_listen, [{port, 1680}]},
     % HTTP port for web-administration and REST API


### PR DESCRIPTION
A few comments:
- {extensions, []} is a plain list of application names, like {extensions, [ciscoms, bbonepush]}.
- building complete server requires the extensions application to be already pre-built global in the system or to be specified in rebar.config as a dependency.
- extension specific configurations goes into appropriate {extensionName, [{},]} section of the lorawan_server.config.

Starting/stopping: These are obvious, but server startup must fail, if the extension fails to start. Server shutdown shall not fail if the extension fails to stop.

Extensions utilizing server API, like one in lorawan_gw_router, do need access to public data structures. (Notes on the API I use I'll send by e-mail).