### PR TITLE
Reverse clustering behaviour

### DIFF
--- a/priv/admin/admin.js
+++ b/priv/admin/admin.js
@@ -139,8 +139,8 @@ myApp.config(['NgAdminConfigurationProvider', function (nga) {
         nga.field('health_alerts', 'choices').label('Alerts')
     ])
     .batchActions([]);
-    servers.creationView().title('Join Cluster Node')
-    .description('Local database in this node will be DELETED, then the remote cluster will be joined')
+    servers.creationView().title('Join Remote Node to Cluster')
+    .description('Local database on the node you enter will be DELETED, then it will be attached to this server!')
     .fields([
         nga.field('sname').label('Name')
     ]);

--- a/src/lorawan_admin_servers.erl
+++ b/src/lorawan_admin_servers.erl
@@ -117,12 +117,12 @@ handle_write(Req, State) ->
     end.
 
 write_server(Req, #server{sname=NodeName}=Server, State) ->
-    case lorawan_db:join_cluster(NodeName) of
+    case lorawan_db:join_cluster(node(), NodeName) of
         ok ->
             ok = mnesia:dirty_write(Server),
             {true, Req, State};
         {error, Error} ->
-            lager:error("Cannot join cluster ~p: ~p", [NodeName, Error]),
+            lager:error("Cannot join node ~p to cluster: ~p", [NodeName, Error]),
             {stop, cowboy_req:reply(400, Req), State}
     end.
 


### PR DESCRIPTION
Addition of the node to cluster via web-interface is now reversed.
Now you must add new nodes to the cluster **from the master** server.