### PR TITLE
Fix integer arithmetic on timestamps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM erlang:20-alpine
 MAINTAINER Petr Gotthard <petr.gotthard@centrum.cz>
 
 RUN apk add --no-cache --virtual build-deps git make wget nodejs-npm && \
-    git clone https://github.com/gotthardp/lorawan-server.git && \
+    git clone https://github.com/themadsens/lorawan-server.git && \
     cd lorawan-server && \
     make release install && \
     cd .. && \

--- a/src/lorawan_mac_commands.erl
+++ b/src/lorawan_mac_commands.erl
@@ -280,7 +280,7 @@ time_to_gps({Date, {Hours, Min, Secs}}) ->
     TotalSecs = calendar:datetime_to_gregorian_seconds({Date, {Hours, Min, trunc(Secs)}})
             - calendar:datetime_to_gregorian_seconds({{1980, 1, 6}, {0, 0, 0}})
             + 17, % leap seconds
-    1000*TotalSecs + (Secs - trunc(Secs)).
+    trunc(1000*TotalSecs + (Secs - trunc(Secs))).
 
 
 auto_adr(Network, #profile{adr_mode=1}=Profile, #node{adr_flag=1, adr_failed=Failed}=Node)


### PR DESCRIPTION
Fixes a crash when the network time was requested from the end node 

Please note that i had to edit the Dockerfile too in order to "docker build" from github