### PR TITLE
update cowboy to 2.6.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,9 +16,8 @@
 {deps, [
     {lager, "3.6.7"},
     {eid, {git, "https://github.com/jur0/eid.git", {ref, "e06e85479058ec51256738d45c6440d99d915a0d"}}},
-    {cowlib, {git, "https://github.com/ninenines/cowlib", {tag, "2.6.0"}}},
-    {cowboy, {git, "https://github.com/ninenines/cowboy", {tag, "2.5.0"}}},
-    {gun, {git, "https://github.com/ninenines/gun.git", {tag, "1.3.0"}}},
+    {cowboy, "2.6.1"},
+    {gun, "1.3.0"},
     {jsx, "2.9.0"},
     {iso8601, "1.3.1"},
     {cbor, {git, "https://github.com/yjh0502/cbor-erlang.git", {ref, "b5c9dbc2de15753b2db15e13d88c11738c2ac292"}}},


### PR DESCRIPTION
cowlib is included by cowboy
I think rebar.lock is need by erlang project, add it.