### PR TITLE
Installation.md: build dependency rsync

### DIFF
--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -171,7 +171,8 @@ deb-src http://deb.nodesource.com/node_6.x stretch main
 
 Then, obtain the build prerequisites:
 ```bash
-sudo apt-get install git erlang-dev erlang-parsetools erlang-src erlang-eunit nodejs
+sudo apt-get install git erlang-dev erlang-parsetools erlang-src erlang-eunit \
+     nodejs rsync
 ```
 
 Get the latest lorawan-server sources by:


### PR DESCRIPTION
Building the Debian package requires rsync.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>