### PR TITLE
config: use %%-*-erlang-*- as first line

### DIFF
--- a/lorawan_server.config
+++ b/lorawan_server.config
@@ -1,3 +1,4 @@
+%%-*-erlang-*-
 [
 % server configuration
 {lorawan_server, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+%%-*-erlang-*-
 {require_min_otp_vsn, "R19"}.
 
 {erl_opts, [


### PR DESCRIPTION
By adding %%-*-erlang-*- as first line in config files Vim and GNU Emacs
can identify these as Erlang based and apply correct syntax coloring.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>