### PR TITLE
lorawan_connector_http: support authentication

### DIFF
--- a/src/lorawan_connector_http.erl
+++ b/src/lorawan_connector_http.erl
@@ -102,8 +102,8 @@ handle_info({gun_response, C, StreamRef, Fin, 401, Headers},
                     {[], State2} ->
                         lager:warning("Authentication failed: ~p", [WWWAuthenticate]),
                         State2;
-                    {Auth, State2} ->
-                        do_publish({URI, authenticated, ContentType, Body}, Auth, State2)
+                    {Auth2, State2} ->
+                        do_publish({URI, authenticated, ContentType, Body}, Auth2, State2)
                 end
         end,
     {noreply, fin_stream(StreamRef, Fin, State3)};


### PR DESCRIPTION
In handle_info/2 an error occurs with basic authentication due to
duplicate use of variable 'Auth'.

Closes issue #545.

Fixes: 8d2fefd8ad42 ("Issues #292,#460: Token based authentication for HTTP")
Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>