### PR TITLE
handle_downlink: allow map returned by downlink function

### DIFF
--- a/doc/Handlers.md
+++ b/doc/Handlers.md
@@ -358,6 +358,7 @@ constructs the binary payload.
 
 This function is optional. If not provided, the downlink data will be taken
 from the `data` field, e.g. when you send `{"devaddr":"11223344", "data":"01"}`.
+The `data` field must be in hexadecimal notation.
 
 If provided, *Build Downlink* shall be a
 [Fun Expression](http://erlang.org/doc/reference_manual/expressions.html#funs)
@@ -365,6 +366,15 @@ with a single parameter, which gets an
 [Erlang representation of JSON](https://github.com/talentdeficit/jsx#json---erlang-mapping)
 and returns
 [binary data](http://erlang.org/doc/programming_examples/bit_syntax.html).
+
+JSON data is converted to a map. Fields taken from the MQTT topic are added to
+the map. This map is passed as sole parameter to the downlink function. The
+download function may either return a binary or a map. If a binary is returned
+this binary is used to fill the `data` field which is sent to the device. If the
+downlink function returns a map this map replaces the original map. All relevant
+fields like `devaddr`, `deveui`, `port`, and `data` may be set in the downlink
+function.
+
 For example, if you send `{"devaddr":"11223344", "led":1}`, you can have a function
 like this to convert the custom field (`led`) to downlink data:
 
@@ -386,5 +396,17 @@ To build a variable sized array you can do:
 ```erlang
 fun(#{data := Data}) ->
   <<(length(Data)), (list_to_binary(Data))/binary>>
+end.
+```
+
+Here is a simple example just adding a `port` and a `data` field to the original
+map:
+
+```erlang
+fun(Fields) ->
+  Fields#{
+    port => 43,
+    data => << 16#88 >>
+  }
 end.
 ```


### PR DESCRIPTION
Up to now we could only set the 'data' field via the binary return value of
the downlink function.

With the patch we allow the downlink function to return either a binary or
a map.

If a binary is returned, it is used to update the 'data' value.

If a map is returned, this map replaces the original map passed to the
downlink function. All relevant download fields like devaddr, deveui, port,
pending, receipt, and data can be set.

Here is a simple example:

    fun(Vars) ->
        Vars#{
            deveui => <<16#3065ECFEFF6FC458:64>>,
            port => 43,
            data => <<16#02, 16#0113:16/little>>
        }
    end.

Closes #572.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>