### PR TITLE
MQTT connector: retain flag

### DIFF
--- a/doc/Handlers.md
+++ b/doc/Handlers.md
@@ -322,6 +322,18 @@ The expression `#{name1 => A, name2 => B, name3 => C}` then creates (depending o
 your [Connector](Connectors.md) settings) a JSON `{"name1":A, "name2":B, "name3":C}`,
 or a Web-Form `name1=A&name2=B&name3=C`.
 
+### Retained Messages
+
+The field retain has a special meaning for the MQTT handler:
+
+ * retain = false - create a non-retained message
+ * retain = true - create a retained message
+ * retain = delete - delete the retained message and create a non-retained
+   message
+
+The field retain is not sent in the message to the MQTT handler.
+
+If the field retain is not present, a non-retained message is created.
 
 ## Parse Event
 


### PR DESCRIPTION
The retain flag in the uplink message to an MQTT server signals that the
message content shall be kept and presented to any client subscribing to
the topic at a later moment.

With the patch the retain flag can be set in the uplink function of the
handler.

retain = true       - create a retained record
retain = delete     - delete the retained record and create a non-retained
                      record.
none or other value - create a non-retained record

To avoid sending irrelevant data the field 'retain' is removed from the
message sent to the MQTT server.

Closes #579

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>