### PR TITLE
Replace *some* of the obsolete string: functions

### DIFF
--- a/src/lorawan_admin.erl
+++ b/src/lorawan_admin.erl
@@ -450,11 +450,11 @@ parse_opt(Field, List) ->
     parse_opt(Field, List, undefined).
 
 intervals_to_text(List) when is_list(List) ->
-    lists:flatten(string:join(
+    lists:flatten(lists:join(", ",
         lists:map(
             fun ({A, A}) -> integer_to_list(A);
                 ({B, C}) -> [integer_to_list(B), "-", integer_to_list(C)]
-            end, List), ", "));
+            end, List)));
 intervals_to_text(_) ->
     % this is for backward compatibility, will be removed in few months
     % I don't think anyone ever used anything else than 7
@@ -463,11 +463,11 @@ intervals_to_text(_) ->
 text_to_intervals(Text) ->
     lists:map(
         fun (Item) ->
-            case string:tokens(Item, "- ") of
+            case string:lexemes(Item, "- ") of
                 [A] -> {list_to_integer(A), list_to_integer(A)};
                 [B, C] -> {list_to_integer(B), list_to_integer(C)}
             end
-        end, string:tokens(Text, ";, ")).
+        end, string:lexemes(Text, ";, ")).
 
 set_body_json_id(Key, Value, Req) ->
     cowboy_req:set_resp_body(

--- a/src/lorawan_connector.erl
+++ b/src/lorawan_connector.erl
@@ -24,9 +24,9 @@ pid_to_binary(Pid, Idx) ->
     <<(pid_to_binary(Pid))/binary, "/", (integer_to_binary(Idx))/binary>>.
 
 is_pattern(Pattern) ->
-    case string:chr(Pattern, ${) of
-        0 -> false;
-        N when N > 0 -> true
+    case string:find(Pattern, "{") of
+        nomatch -> false;
+        _ -> true
     end.
 
 pattern_for_cowboy(Empty)

--- a/src/lorawan_connector_mongodb.erl
+++ b/src/lorawan_connector_mongodb.erl
@@ -33,7 +33,7 @@ init([#connector{connid=Id, app=App, uri= <<"mongodb://", Servers0/binary>>,
     % connect
     {UserName, Password} = credentials(Connector),
     mongodb:replicaSets(Pool, 10,
-        string:tokens(binary_to_list(Servers0), ", "), UserName, Password),
+        string:lexemes(binary_to_list(Servers0), ", "), UserName, Password),
     mongodb:connect(Pool),
     try
         {ok, #state{

--- a/src/lorawan_control.erl
+++ b/src/lorawan_control.erl
@@ -18,7 +18,7 @@ stop() ->
 
 invoke(Module, Fun, Params) ->
     % use short names, so only the first part of the hostname
-    [Host | _] = string:tokens(net_adm:localhost(), "."),
+    [Host | _] = string:lexemes(net_adm:localhost(), "."),
     Node = list_to_atom(string:join(["lorawan", Host], "@")),
     case rpc:call(Node, Module, Fun, Params) of
         ok -> ok;

--- a/src/lorawan_db_guard.erl
+++ b/src/lorawan_db_guard.erl
@@ -250,7 +250,7 @@ send_emails(Admins, Type, ID, Message, Warning) ->
 send_emails0([#config{admin_url=Prefix, email_from=From, email_server=Server,
         email_user=User, email_password=Pass}], ToAddrs, Type, ID, Message, Warning)
         when byte_size(From) > 0, byte_size(Server) > 0, length(ToAddrs) > 0 ->
-    TypeTitle = titlecase(Type),
+    TypeTitle = string:titlecase(Type),
     Body =
         {<<"multipart">>, <<"alternative">>, [
             {<<"From">>, From},
@@ -310,7 +310,7 @@ send_slack_message(Channel, Type, ID, Message, Warning) ->
     [#config{admin_url=Prefix, slack_token=Token}] = mnesia:dirty_read(config, <<"main">>),
     send_slack_raw(
         Token, Channel,
-        list_to_binary([titlecase(Type), " <", stringify_url(Prefix, Type, ID), "|", ID, ">", Message,
+        list_to_binary([string:titlecase(Type), " <", stringify_url(Prefix, Type, ID), "|", ID, ">", Message,
             if
                 Warning ->
                     " :warning:";
@@ -506,9 +506,5 @@ expired_events() ->
         calendar:datetime_to_gregorian_seconds(calendar:universal_time()) - AgeSeconds),
     mnesia:dirty_select(event,
         [{#event{evid='$1', last_rx='$2', _='_'}, [{'=<', '$2', {const, ETime}}], ['$1']}]).
-
-% string:titlecase is not available in Erlang 19
-titlecase([F|Rest]) ->
-    [string:to_upper(F) | Rest].
 
 % end of file

--- a/src/lorawan_gw_forwarder.erl
+++ b/src/lorawan_gw_forwarder.erl
@@ -94,7 +94,7 @@ handle_info({udp, Socket, _Host, _Port, <<_Version, Token:16, 5, MAC:8/binary, D
                         <<"NONE">> -> ok;
                         Error ->
                             lorawan_gw_router:downlink_error(MAC, DevAddr,
-                                list_to_binary(string:to_lower(binary_to_list(Error))))
+                                string:lowercase(Error))
                     end;
                 _ ->
                     lager:error("Ignored TX_ACK from ~s: JSON syntax error: ~s", [lorawan_utils:binary_to_hex(MAC), Data])

--- a/src/lorawan_http_digest.erl
+++ b/src/lorawan_http_digest.erl
@@ -69,9 +69,9 @@ digest_test_() -> [
             <<"00000001">>, <<"0a4f113b">>, <<"auth">>))].
 
 integer_to_hex(Num, Len) ->
-    list_to_binary(string:right(string:to_lower(integer_to_list(Num,16)), Len, $0)).
+    list_to_binary(string:right(string:lowercase(integer_to_list(Num,16)), Len, $0)).
 
 binary_to_hex(Id) ->
-    << <<Y>> || <<X:4>> <= Id, Y <- string:to_lower(integer_to_list(X,16))>>.
+    << <<Y>> || <<X:4>> <= Id, Y <- string:lowercase(integer_to_list(X,16))>>.
 
 % end of file


### PR DESCRIPTION
One call to string:join and one call to string:right remain in the code - direct replacement with lists:join/2 and string:pad/3, as recommended, will require extra calls to lists:flatten/1. The only potential benefit of the 'recommended' function set, apart from being non-obsolete, is its inherent Unicode support.