### PR TITLE
Typo in $scope.value checks in 'admin.js' Fixes #732

### DIFF
--- a/priv/admin/admin.js
+++ b/priv/admin/admin.js
@@ -1746,7 +1746,7 @@ return {
     },
     link: function($scope) {
             function updateData() {
-                if (!value in $scope)
+                if (!'value' in $scope)
                     return
                 $http({method: 'GET', url: '/admin/sgraph/'.concat($scope.value)})
                     .then(function(response) {
@@ -1797,7 +1797,7 @@ return {
     },
     link: function($scope) {
             function updateData() {
-                if (!value in $scope)
+                if (!'value' in $scope)
                     return
                 $http({method: 'GET', url: '/admin/pgraph/'.concat($scope.value)})
                     .then(function(response) {
@@ -1847,7 +1847,7 @@ return {
     },
     link: function($scope) {
             function updateData() {
-                if (!value in $scope)
+                if (!'value' in $scope)
                     return
                 $http({method: 'GET', url: '/admin/tgraph/'.concat($scope.value)})
                     .then(function(response) {
@@ -1899,7 +1899,7 @@ return {
     },
     link: function($scope) {
             function updateData() {
-                if (!value in $scope)
+                if (!'value' in $scope)
                     return
                 $http({method: 'GET', url: '/admin/rgraph/'.concat($scope.value)})
                     .then(function(response) {
@@ -1954,7 +1954,7 @@ return {
     },
     link: function($scope) {
             function updateData() {
-                if (!value in $scope)
+                if (!'value' in $scope)
                     return
                 $http({method: 'GET', url: '/admin/qgraph/'.concat($scope.value)})
                     .then(function(response) {
@@ -2008,7 +2008,7 @@ return {
     },
     link: function($scope) {
             function updateData() {
-                if (!value in $scope)
+                if (!'value' in $scope)
                     return
                 $http({method: 'GET', url: '/admin/ngraph/'.concat($scope.value)})
                     .then(function(response) {


### PR DESCRIPTION
Checks for the element presence should be of the form ``` 'value' in ... ```, not ```value in ...```