### PR TITLE
Use multi-stage build for docker builds to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@
 FROM erlang:21-alpine AS scratch
 MAINTAINER Petr Gotthard <petr.gotthard@centrum.cz>
 
-RUN apk add --no-cache --virtual build-deps git make wget nodejs-npm && \
-    git clone https://github.com/gotthardp/lorawan-server.git && \
-    cd lorawan-server && \
-    make release
+RUN apk add --no-cache --virtual build-deps git make wget nodejs-npm
+
+WORKDIR /lorawan-server
+
+COPY . ./
+
+RUN make release
 
 # Deployment container
 FROM erlang:alpine


### PR DESCRIPTION
This also fixes a bug where built docker containers would always use the latest master commit, since it's running git clone in the Dockerfile.

Now the files are copied from the commit that is checked out.