### PR TITLE
Switch email separator from ";" to ","

### DIFF
--- a/src/lorawan_db_guard.erl
+++ b/src/lorawan_db_guard.erl
@@ -254,7 +254,7 @@ send_emails0([#config{admin_url=Prefix, email_from=From, email_server=Server,
     Body =
         {<<"multipart">>, <<"alternative">>, [
             {<<"From">>, From},
-            {<<"To">>, lists:join(<<";">>, ToAddrs)},
+            {<<"To">>, lists:join(<<",">>, ToAddrs)},
             {<<"Subject">>, list_to_binary([TypeTitle, " ", ID])},
             {<<"MIME-Version">>, <<"1.0">>},
             {<<"Content-Type">>, <<"multipart/alternative; boundary=bound-123234234">>}] ++


### PR DESCRIPTION
According to the RFC, email addresses should be separated by a comma.

https://tools.ietf.org/html/rfc5322#section-3.6.3

This came up because I we have been trying to configure our server to send using SES and the server started crashing with the following error message: 

```
2020-11-06 16:33:34 =SUPERVISOR REPORT====
     Supervisor: {local,gun_sup}
     Context:    child_terminated
     Reason:     {{owner_gone,{{nocatch,{permanent_failure,<<"554 Transaction failed: Illegal semicolon, not in group\r\n">>}},[{gen_smtp_client,try_DATA,4,[{file,"/lorawan-server/_build/default/lib/gen_smtp/src/gen_smtp_client.erl"},{line,333}]},{gen_smtp_client,send_it,2,[{file,"/lorawan-server/_build/default/lib/gen_smtp/src/gen_smtp_client.erl"},{line,193}]},{gen_smtp_client,send_it_nonblock,3,[{file,"/lorawan-server/_build/default/lib/gen_smtp/src/gen_smtp_client.erl"},{line,114}]}]}},[{gun,owner_gone,1,[{file,"/lorawan-server/_build/default/lib/gun/src/gun.erl"},{line,966}]},{gun,proc_lib_hack,5,[{file,"/lorawan-server/_build/default/lib/gun/src/gun.erl"},{line,649}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
     Offender:   [{pid,<0.412.0>},{id,gun},{mfargs,{gun,start_link,undefined}},{restart_type,temporary},{shutdown,5000},{child_type,worker}]
```

This change should solve this problem.

Additional reference: https://forums.aws.amazon.com/thread.jspa?threadID=118409