### PR TITLE
Eliminate tuple_calls in mongodb connector. Fixes #687

### DIFF
--- a/src/lorawan_connector_mongodb.erl
+++ b/src/lorawan_connector_mongodb.erl
@@ -109,8 +109,8 @@ store_fields(Pool, Pattern, Vars0) ->
                 {<<"local">>, CN}
         end,
     Mong = mongoapi:new(Pool, Database),
-    Mong:createCollection(Collection),
-    {ok, _} = Mong:save(Collection, prepare_bson(Vars0)).
+    mongoapi:createCollection(Collection, Mong),
+    {ok, _} = mongoapi:save(Collection, prepare_bson(Vars0), Mong).
 
 prepare_bson(Data) ->
     maps:map(


### PR DESCRIPTION
tuple_calls workaround rebar directive fails under some rare circumstances, better to remove it completely. This fixes observed cases with mongodb connector failing on some installations.