### PR TITLE
Attempt periodic restart of failed Connectors

### DIFF
--- a/src/lorawan_backend_sup.erl
+++ b/src/lorawan_backend_sup.erl
@@ -20,7 +20,10 @@ init([]) ->
             permanent, infinity, supervisor, [lorawan_connector_sup]},
         {factory,
             {lorawan_backend_factory, start_link, []},
-            permanent, 5000, worker, [lorawan_backend_factory]}
+            permanent, 5000, worker, [lorawan_backend_factory]},
+        {monitor,
+            {lorawan_connector_monitor, start_link, []},
+            permanent, 5000, worker, [lorawan_connector_monitor]}
     ]}}.
 
 % end of file

--- a/src/lorawan_connector_monitor.erl
+++ b/src/lorawan_connector_monitor.erl
@@ -27,8 +27,8 @@ init([]) ->
 handle_call(_Request, _From, State) ->
     {stop, {error, unknownmsg}, State}.
 
-handle_cast(_Msg, State) ->
-    {noreply, State}.
+handle_cast(_Msg, #state{period=Period}=State) ->
+    {noreply, State, Period}.
 
 handle_info(timeout, #state{period=Period}=State) ->
     % run through known connectors, attempt restart if failed with 'network'
@@ -40,9 +40,9 @@ handle_info(timeout, #state{period=Period}=State) ->
         mnesia:dirty_all_keys(connector)),
     {noreply, State, Period};
 
-handle_info(Info, State) ->
+handle_info(Info, #state{period=Period}=State) ->
     lager:debug("unknown info ~p", [Info]),
-    {noreply, State}.
+    {noreply, State, Period}.
 
 terminate(_Reason, _State) ->
     ok.

--- a/src/lorawan_connector_monitor.erl
+++ b/src/lorawan_connector_monitor.erl
@@ -1,0 +1,59 @@
+%
+% Copyright (c) 2016-2019 Petr Gotthard <petr.gotthard@centrum.cz>
+% All rights reserved.
+% Distributed under the terms of the MIT License. See the LICENSE file.
+%
+-module(lorawan_connector_monitor).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+-include("lorawan_db.hrl").
+
+-record(state, {period}).
+
+% Default connector health check period 10 seconds
+-define(DEFAULT_PERIOD, 10000).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    Period = application:get_env(lorawan_server, connector_monitor_period,
+            ?DEFAULT_PERIOD),
+    {ok, #state{period=Period}, Period}.
+
+handle_call(_Request, _From, State) ->
+    {stop, {error, unknownmsg}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(timeout, #state{period=Period}=State) ->
+    % run through known connectors, attempt restart if failed with 'network'
+    lists:foreach(
+        fun(ConnId) ->
+            [Connector] = mnesia:dirty_read(connector, ConnId),
+            restart_connector(Connector)
+        end,
+        mnesia:dirty_all_keys(connector)),
+    {noreply, State, Period};
+
+handle_info(Info, State) ->
+    lager:debug("unknown info ~p", [Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+restart_connector(#connector{enabled=true, failed=[<<"network">>]}=Connector) ->
+    {atomic, ok} = mnesia:transaction(
+        fun() ->
+            lorawan_admin:write(Connector#connector{failed=[]})
+        end);
+restart_connector(_Connector) ->
+    ok.

--- a/src/lorawan_server.app.src
+++ b/src/lorawan_server.app.src
@@ -41,6 +41,7 @@
         {deduplication_delay, 200},
         {server_stats_interval, 60}, % [s]
         {slack_server, {"slack.com", 443}},
+        {connector_monitor_period, 10000}, % ms
         {trim_interval, 3600}, % [s]
         {event_lifetime, 86400}
     ]},


### PR DESCRIPTION
A separate gen_server sitting under backend_sup will periodically scan `connector` table for the entries failed with <<"network">> error code and attempt their restart in case it was connection problem. Only enabled connectors with **single** <<"network">> error will be considered, disabled connectors or connectors having other errors as well will not be attempted.