### PR TITLE
Bug in Dockerfile - must specify OTP 21 explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache --virtual build-deps git make wget nodejs-npm && \
     make release
 
 # Deployment container
-FROM erlang:alpine
+FROM erlang:21-alpine
 
 ## Not likely to change with rebuilds
 


### PR DESCRIPTION
Docker container run may exhibit strange behaviour when code compiled for OTP/21 is run on default OTP/24. We must specify OTP/21 explicitly for image creation.