### PR TITLE
pass TERM signal to underlying process and improve shutdown

### DIFF
--- a/scripts/lorawan-server
+++ b/scripts/lorawan-server
@@ -23,4 +23,14 @@ else
     ERL_ARGS="-lager log_root \"log\""
 fi
 
-cd $LORAWAN_HOME && erl -noinput +Bd -sname lorawan -pa $ROOT_DIR/lib/*/ebin -s lorawan_app $ERL_ARGS -config $SYS_CONFIG $@
+# trap function and kill underlying process 
+function killer() {
+    kill $!
+    wait $!
+}
+
+# install trap
+trap killer TERM
+
+cd $LORAWAN_HOME && erl -noinput +Bd -sname lorawan -pa $ROOT_DIR/lib/*/ebin -s lorawan_app $ERL_ARGS -config $SYS_CONFIG $@ &
+wait $!


### PR DESCRIPTION
The lorawan-server script doesn't forward TERM signal to underlying process. 

Normally the underlying process must be started from the starting script with "exec", but only if it is a binary executable (which "erl" is not; from tests carried out it works, but two "zombie" processes remain active). In this modification, a trap forwards the term signal.

In solution to #843